### PR TITLE
Pass cananocial name when updating records

### DIFF
--- a/lib/powerdnsex/managers/records_manager.ex
+++ b/lib/powerdnsex/managers/records_manager.ex
@@ -21,7 +21,7 @@ defmodule PowerDNSex.Managers.RecordsManager do
   end
 
   def update(%Zone{} = zone, %{name: rrset_name, type: rrset_type} = rrset_attrs) do
-    rrset_find_params = %{name: "#{rrset_name}.#{zone.name}", type: rrset_type}
+    rrset_find_params = %{name: rrset_name, type: rrset_type}
     rrset = RRSet.find(zone.rrsets, rrset_find_params)
 
     if rrset do


### PR DESCRIPTION
The PowerDNS API spec requires a full canonical name when performing a REPLACE changeset,
however the power_dnsex wrapper is inconsistent with this spec in its update_record() method.
This fixes the inconsistency so that the record map behaves the same as the create_record()
method.

I wasn't able to figure out how to run the test suite, the setup seems developer-specific. I did check the update tests, and they are in fact using a full canonical name, so no adjustment may be necessary there.