### PR TITLE
Add usage examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,68 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
     end
     ```
 
+## Example usage
+
+```elixir
+# CREATE ZONE:
+zone_model = %PowerDNSex.Models.Zone{
+  id: "example.com.",
+  kind: "Master",
+  name: "example.com.",
+  serial: 1,
+}
+{:ok, zone} = PowerDNSex.create_zone(zone_model)
+
+# SHOW ZONE:
+{:ok, zone} = PowerDNSex.show_zone("example.com")
+
+# DELETE ZONE:
+res = PowerDNSex.delete_zone("example.com")
+
+# CREATE RECORD:
+{:ok, zone} = PowerDNSex.show_zone("example.com")
+record = %{
+  name: "test.example.com.",
+  type: "A",
+  ttl: 60,
+  records: [
+    %{
+      content: "192.168.11.67",
+      disabled: false,
+    }
+  ]
+}
+res = PowerDNSex.create_record(zone, record)
+
+# SHOW RECORD:
+record = %{
+  name: "test.example.com.",
+  type: "A",
+}
+rrset = PowerDNSex.show_record("example.com", record)
+
+# UPDATE RECORD:
+{:ok, zone} = PowerDNSex.show_zone("example.com")
+record = %{
+  name: "test.example.com.",
+  type: "A",
+  ttl: 60,
+  records: [
+    %{
+      content: "192.168.11.100",
+      disabled: false,
+    }
+  ]
+}
+res = PowerDNSex.update_record(zone, record)
+
+# DELETE RECORD:
+{:ok, zone} = PowerDNSex.show_zone("example.com")
+record = %{
+  name: "test.example.com.",
+  type: "A",
+}
+rrset = PowerDNSex.show_record("example.com", record)
+res = PowerDNSex.delete_record(zone, rrset)
+
+```


### PR DESCRIPTION
The module works great! And, it took me quite a while digging around in the source code to understand how to use it, particularly the structure of the arguments to pass all the high-level CRUD functions for zones/records.

This PR codifies my learning efforts into an 'Example usage' section of the README. Hopefully it will help others get up to speed more quickly.